### PR TITLE
chore(waves): use global object for require

### DIFF
--- a/src/waves/waves.js
+++ b/src/waves/waves.js
@@ -34,7 +34,7 @@ export class MdWaves {
     }
 
     this.attributeManager.addClasses(classes);
-    if (!(typeof require === "function" && typeof require.specified === "function" && require.specified('waves'))) {
+    if (!(typeof window.require === "function" && typeof window.require.specified === "function" && window.require.specified('waves'))) {
       Waves.attach(this.element);
     }
   }


### PR DESCRIPTION
webpack has it's own requre so it fail build
when just asking for require.specified.
Translated to **webpack__require**().specified
